### PR TITLE
Expand on the C compiler/ruby headers requirement for mysql::ruby

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Cookbooks
 Requires Opscode's openssl cookbook for secure password generation.
 See _Attributes_ and _Usage_ for more information.
 
-**Note**: The RubyGem installation in the `mysql::ruby` recipe requires a C
+**Note**: the RubyGem installation in the `mysql::ruby` recipe requires a C
 compiler and Ruby development headers to be installed _at compile time_ (as Chef 
 [identifies the resources to be run](http://docs.opscode.com/essentials_nodes_chef_run.html))
 in order to build the mysql gem. When using the `build-essential` cookbook, for instance,

--- a/README.md
+++ b/README.md
@@ -31,9 +31,12 @@ Cookbooks
 Requires Opscode's openssl cookbook for secure password generation.
 See _Attributes_ and _Usage_ for more information.
 
-The RubyGem installation in the `mysql::ruby` recipe requires a C
-compiler and Ruby development headers to be installed in order to
-build the mysql gem.
+**Note**: The RubyGem installation in the `mysql::ruby` recipe requires a C
+compiler and Ruby development headers to be installed _at compile time_ (as Chef 
+[identifies the resources to be run](http://docs.opscode.com/essentials_nodes_chef_run.html))
+in order to build the mysql gem. When using the `build-essential` cookbook, for instance,
+make sure to include `node.set['build_essential']['compiletime'] = true` in the recipe
+including build_essential to ensure proper load order. 
 
 Requires `homebrew`
 [cookbook](http://community.opscode.com/cookbooks/homebrew) on Mac OS

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ compiler and Ruby development headers to be installed _at compile time_ (as Chef
 [identifies the resources to be run](http://docs.opscode.com/essentials_nodes_chef_run.html))
 in order to build the mysql gem. When using the `build-essential` cookbook, for instance,
 make sure to include `node.set['build_essential']['compiletime'] = true` in the recipe
-including build_essential to ensure proper load order. 
+including build-essential to ensure proper load order. 
 
 Requires `homebrew`
 [cookbook](http://community.opscode.com/cookbooks/homebrew) on Mac OS


### PR DESCRIPTION
That mysql::ruby executes at compile-time tripped me up for several hours yesterday. Until users become familiar with the anatomy of a Chef run (probably by encountering a situation like this), it's not immediately clear that it's even possible for recipes to (essentially) run in a different order than the one they're specified in. This change expands on the existing warning in the readme to make the mysql::ruby preconditions clearer, and provides an example of how to do that with build-essential.
